### PR TITLE
Enable running Launcher from IntelliJ

### DIFF
--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
@@ -27,7 +27,7 @@ public class JournalAbbreviationLoader {
         try {
             Path tempDir = Files.createTempDirectory("jabref-journal");
             Path tempJournalList = tempDir.resolve("journalList.mv");
-            Files.copy(JournalAbbreviationRepository.class.getResourceAsStream("/journals/journalList.mv"), tempJournalList);
+            Files.copy(JournalAbbreviationRepository.class.getClassLoader().getResourceAsStream("journals/journalList.mv"), tempJournalList);
             repository = new JournalAbbreviationRepository(tempJournalList);
             tempDir.toFile().deleteOnExit();
             tempJournalList.toFile().deleteOnExit();

--- a/src/main/java/org/jabref/logic/net/ssl/TrustStoreManager.java
+++ b/src/main/java/org/jabref/logic/net/ssl/TrustStoreManager.java
@@ -139,7 +139,7 @@ public class TrustStoreManager {
     public static void createTruststoreFileIfNotExist(Path storePath) {
         try {
             LOGGER.debug("Trust store path: {}", storePath.toAbsolutePath());
-            Path storeResourcePath = Path.of(TrustStoreManager.class.getResource("/ssl/truststore.jks").toURI());
+            Path storeResourcePath = Path.of(TrustStoreManager.class.getClassLoader().getResource("ssl/truststore.jks").toURI());
             Files.createDirectories(storePath.getParent());
             if (Files.notExists(storePath)) {
                 Files.copy(storeResourcePath, storePath);

--- a/src/main/java/org/jabref/logic/protectedterms/ProtectedTermsParser.java
+++ b/src/main/java/org/jabref/logic/protectedterms/ProtectedTermsParser.java
@@ -33,8 +33,14 @@ public class ProtectedTermsParser {
     private String location;
 
     public void readTermsFromResource(String resourceFileName, String descriptionString) {
-        URL url = Objects
-                .requireNonNull(ProtectedTermsLoader.class.getResource(Objects.requireNonNull(resourceFileName)));
+        URL resource = ProtectedTermsLoader.class.getResource(Objects.requireNonNull(resourceFileName));
+        if (Objects.isNull(resource)) {
+            // Workaround for the case when using IntelliJ
+            // input resourceFileName starts with a "/"
+            // When using "getClassLoader()", the "/" must not be used
+            resource = ProtectedTermsParser.class.getClassLoader().getResource(resourceFileName.substring(1));
+        }
+        URL url = Objects.requireNonNull(resource);
         description = descriptionString;
         location = resourceFileName;
         try {

--- a/src/main/java/org/jabref/logic/util/BuildInfo.java
+++ b/src/main/java/org/jabref/logic/util/BuildInfo.java
@@ -10,7 +10,7 @@ import java.util.Properties;
 
 public final class BuildInfo {
 
-    public static final String UNKNOWN_VERSION = "*unknown*";
+    public static final String UNKNOWN_VERSION = "unknown";
 
     public static final String OS = System.getProperty("os.name", UNKNOWN_VERSION);
     public static final String OS_VERSION = System.getProperty("os.version", UNKNOWN_VERSION).toLowerCase(Locale.ROOT);

--- a/src/test/java/org/jabref/logic/util/BuildInfoTest.java
+++ b/src/test/java/org/jabref/logic/util/BuildInfoTest.java
@@ -10,7 +10,7 @@ public class BuildInfoTest {
     @Test
     public void testDefaults() {
         BuildInfo buildInfo = new BuildInfo("asdf");
-        assertEquals("*unknown*", buildInfo.version.getFullVersion());
+        assertEquals("unknown", buildInfo.version.getFullVersion());
     }
 
     @Test


### PR DESCRIPTION
While working on https://github.com/JabRef/jabref/pull/9355 (a refined guide for IntelliJ), I found out, that it is not possible to start `Launcher`.

This PR outlines fixes. I think, these are all wrong, because, [IntelliJ IDEA - getClass().getResource("...") return null](https://stackoverflow.com/questions/26328040/intellij-idea-getclass-getresource-return-null).

---

When starting from IntelliJ using `Launcher`, I get following exception:

```
Exception in thread "main" java.nio.file.InvalidPathException: Illegal char <*> at index 53: C:\Users\koppor\AppData\Local\org.jabref\jabref\Logs\*unknown*
	at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
	at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
	at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:232)
	at java.base/java.nio.file.Path.of(Path.java:147)
	at org.jabref/org.jabref.cli.Launcher.addLogToDisk(Launcher.java:94)
	at org.jabref/org.jabref.cli.Launcher.main(Launcher.java:51)
```

I traced it down to following code

    public static final String UNKNOWN_VERSION = "*unknown*";

I removed the starts and now JabRef runs.

---

Then, I got a bunch of exception, because `.class.getResource(...)` is always null at IntelliJ.
I tried solutions from https://stackoverflow.com/q/26328040/873282. The main solutions were

- Use `getClassLoader`
- Do NOT prefix the filname with `/`.

However, then I would have had to prefix each filename with the package name path. This is IMHO unreadable. So, I skipped and will try to create an MWE and file an IntelliJ issue.

Notes:

```
ERROR: Unexpected exception: java.lang.NullPointerException: Cannot invoke "java.net.URL.toURI()" because the return value of "java.lang.Class.getResource(String)" is null
	at org.jabref/org.jabref.logic.net.ssl.TrustStoreManager.createTruststoreFileIfNotExist(TrustStoreManager.java:142)
	at org.jabref/org.jabref.cli.Launcher.configureSSL(Launcher.java:174)
	at org.jabref/org.jabref.cli.Launcher.main(Launcher.java:65)
...
ERROR: Unexpected exception: java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:208)
	at java.base/java.nio.file.Files.copy(Files.java:3129)
	at org.jabref/org.jabref.logic.journals.JournalAbbreviationLoader.loadRepository(JournalAbbreviationLoader.java:30)
	at org.jabref/org.jabref.cli.Launcher.applyPreferences(Launcher.java:144)
	at org.jabref/org.jabref.cli.Launcher.main(Launcher.java:66)
```
