### PR TITLE
Add user name and host name to user-specific file directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added a link "Get more themes..." in the preferences to that points to [themes.jabref.org](https://themes.jabref.org) allowing the user to download new themes. [#10243](https://github.com/JabRef/jabref/issues/10243)
 - We added a fetcher for [LOBID](https://lobid.org/resources/api) resources. [koppor#386](https://github.com/koppor/jabref/issues/386)
 - When in `biblatex` mode, the [integrity check](https://docs.jabref.org/finding-sorting-and-cleaning-entries/checkintegrity) for journal titles now also checks the field `journal`.
-
+- We added a hover on user-specific file directory. If the mouse is on hower, JabRef displays: user: {username}, host: {hostname}. [#572](https://github.com/koppor/jabref/issues/572)
 ### Changed
 
 - The export formats `listrefs`, `tablerefs`, `tablerefsabsbib`, now use the ISO date format in the footer [#10383](https://github.com/JabRef/jabref/pull/10383).

--- a/src/main/java/org/jabref/gui/libraryproperties/general/GeneralProperties.fxml
+++ b/src/main/java/org/jabref/gui/libraryproperties/general/GeneralProperties.fxml
@@ -47,9 +47,11 @@
         </Button>
 
         <Label text="%User-specific file directory"
-               GridPane.columnIndex="0" GridPane.rowIndex="2"/>
+               GridPane.columnIndex="0" GridPane.rowIndex="2">
+        </Label>
         <TextField fx:id="userSpecificFileDirectory"
                    GridPane.columnIndex="1" GridPane.rowIndex="2"/>
+
         <Button onAction="#browseUserSpecificFileDirectory"
                 styleClass="icon-button,narrow" prefHeight="20.0" prefWidth="20.0"
                 GridPane.columnIndex="2" GridPane.rowIndex="2">

--- a/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesView.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesView.java
@@ -2,9 +2,11 @@ package org.jabref.gui.libraryproperties.general;
 
 import java.nio.charset.Charset;
 
+import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
 
 import org.jabref.gui.libraryproperties.AbstractPropertiesTabView;
 import org.jabref.gui.util.ViewModelListCellFactory;
@@ -31,6 +33,8 @@ public class GeneralPropertiesView extends AbstractPropertiesTabView<GeneralProp
         ViewLoader.view(this)
                   .root(this)
                   .load();
+        // Get the ViewModel
+        viewModel.setUsername(preferencesService.getFilePreferences().getUserAndHost());
     }
 
     @Override
@@ -53,9 +57,11 @@ public class GeneralPropertiesView extends AbstractPropertiesTabView<GeneralProp
                 .install(databaseMode);
         databaseMode.itemsProperty().bind(viewModel.databaseModesProperty());
         databaseMode.valueProperty().bindBidirectional(viewModel.selectedDatabaseModeProperty());
-
         generalFileDirectory.textProperty().bindBidirectional(viewModel.generalFileDirectoryPropertyProperty());
         userSpecificFileDirectory.textProperty().bindBidirectional(viewModel.userSpecificFileDirectoryProperty());
+        Tooltip tooltip = new Tooltip();
+        tooltip.textProperty().bind(Bindings.concat("Host: ", viewModel.hostPropertyProperty(), "\nUsername: ", viewModel.usernamePropertyProperty()));
+        userSpecificFileDirectory.setTooltip(tooltip);
         laTexFileDirectory.textProperty().bindBidirectional(viewModel.laTexFileDirectoryProperty());
     }
 

--- a/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesViewModel.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.libraryproperties.general;
 
+import java.net.InetAddress;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -33,6 +34,10 @@ public class GeneralPropertiesViewModel implements PropertiesTabViewModel {
     private final SimpleObjectProperty<BibDatabaseMode> selectedDatabaseModeProperty = new SimpleObjectProperty<>(BibDatabaseMode.BIBLATEX);
     private final StringProperty generalFileDirectoryProperty = new SimpleStringProperty("");
     private final StringProperty userSpecificFileDirectoryProperty = new SimpleStringProperty("");
+    private final StringProperty hostProperty = new SimpleStringProperty("");
+
+
+    private final StringProperty usernameProperty = new SimpleStringProperty("");
     private final StringProperty laTexFileDirectoryProperty = new SimpleStringProperty("");
 
     private final DialogService dialogService;
@@ -61,6 +66,16 @@ public class GeneralPropertiesViewModel implements PropertiesTabViewModel {
         selectedDatabaseModeProperty.setValue(metaData.getMode().orElse(BibDatabaseMode.BIBLATEX));
         generalFileDirectoryProperty.setValue(metaData.getDefaultFileDirectory().orElse("").trim());
         userSpecificFileDirectoryProperty.setValue(metaData.getUserFileDirectory(preferencesService.getFilePreferences().getUserAndHost()).orElse("").trim());
+        userSpecificFileDirectoryProperty.setValue(metaData.getUserFileDirectory(preferencesService.getFilePreferences().getUserAndHost()).map(path -> usernameProperty.getValue() + ": " + path).orElse("").trim());
+        String username = preferencesService.getFilePreferences().getUserAndHost();   // get the username
+        usernameProperty.setValue(username);
+        try {
+            InetAddress localHost = InetAddress.getLocalHost();
+            hostProperty.set(localHost.getHostName()); // get the host Name
+        } catch (Exception e) {
+            hostProperty.set("N/A"); // if fail to get host, display N/A（Not Available）
+        }
+
         laTexFileDirectoryProperty.setValue(metaData.getLatexFileDirectory(preferencesService.getFilePreferences().getUserAndHost()).map(Path::toString).orElse(""));
     }
 
@@ -140,5 +155,17 @@ public class GeneralPropertiesViewModel implements PropertiesTabViewModel {
 
     public StringProperty laTexFileDirectoryProperty() {
         return this.laTexFileDirectoryProperty;
+    }
+
+    public void setUsername(String username) {
+        usernameProperty.setValue(username);
+    }
+
+    public StringProperty usernamePropertyProperty() {
+        return usernameProperty;
+    }
+
+    public StringProperty hostPropertyProperty() {
+        return hostProperty;
     }
 }


### PR DESCRIPTION
<!-- 

-->
Fixes #572, user-specific file directory should show user name.
Implement a hover on user-specific file directory. If the mouse is on hower, JabRef displays: user: {username}, host: {hostname}.
![589e2a9a049ace9deb4f7ab3096b275](https://github.com/JoleneSun111/jabref/assets/125976713/dc22cfb5-0b94-4c09-9d74-377c8adabe23) 


Describe the changes you have made here: Change the src/main/java/org/jabref/gui/libraryproperties/general, add two properties to display the username and hostname in the frontend. 
Fixed kopper issue : #572 https://github.com/koppor/jabref/issues/572

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

