### PR TITLE
Add testIeee to ANTLRv3-based BST VM

### DIFF
--- a/src/test/java/org/jabref/logic/bst/TestVM.java
+++ b/src/test/java/org/jabref/logic/bst/TestVM.java
@@ -38,6 +38,16 @@ public class TestVM {
     }
 
     @Test
+    public void testIeee() throws RecognitionException, IOException {
+        VM vm = new VM(new File("src/main/resources/bst/IEEEtran.bst"));
+        List<BibEntry> v = List.of(t1BibtexEntry());
+
+        String expected = "\\begin{thebibliography}{1}\\bibitem{canh05}K.~Crowston, H.~Annabi, J.~Howison, and C.~Masango.\\newblock Effective work practices for floss development: A model and  propositions.\\newblock In {\\em Hawaii International Conference On System Sciences (HICSS)}, 2005.\\end{thebibliography}";
+
+        assertEquals(expected.replaceAll("\\s", ""), vm.run(v).replaceAll("\\s", ""));
+    }
+
+    @Test
     public void testVMSimple() throws RecognitionException, IOException {
 
         VM vm = new VM("ENTRY  { " + "  address " + "  author " + "  title " + "  type "


### PR DESCRIPTION
This adds the ieee test from https://github.com/JabRef/jabref/pull/11234/files#diff-b5c55d3aa722352a825d998f1e417b12684dde5386937e4f69b0f47202a1b7cb to the commit **before** the migration to ANTLR4 (02f51f7b2e395d0cf8d6eb0455e1a1e871a25fd0)

Let's see if it hangs.

Result: It does not hang.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
