### PR TITLE
test

### DIFF
--- a/src/main/java/org/jabref/logic/bibtex/FieldWriter.java
+++ b/src/main/java/org/jabref/logic/bibtex/FieldWriter.java
@@ -162,7 +162,7 @@ public class FieldWriter {
             }
         }
 
-        return formatter.format(stringBuilder, field);
+        return formatter.format(stringBuilder, field) + " ";
     }
 
     private boolean shouldResolveStrings(Field field) {


### PR DESCRIPTION
This tests why gradle behaves differently on the CI than locally. See https://github.com/JabRef/jabref/pull/11282#issuecomment-2148496510 for more information.

I run a `git bisect` locally. I add a breaking change. I force-push this change to `testci` and see what the CI does.

```diff
- return formatter.format(stringBuilder, field);
- return formatter.format(stringBuilder, field) + " ";
```

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
