### PR TITLE
Properly Copy Associated PDFs Between .bib Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added an exporter and improved the importer for Endnote XML format. [#11137](https://github.com/JabRef/jabref/issues/11137)
 - We added support for using BibTeX Style files (BST) in the Preview. [#11102](https://github.com/JabRef/jabref/issues/11102)
 - We added support for automatically update LaTeX citations when a LaTeX file is created, removed, or modified. [#10585](https://github.com/JabRef/jabref/issues/10585)
+- We Added functionality to copy associated PDF files when moving entries between `.bib` files, ensuring linked PDFs are also transferred to the destination's designated file directory. [#520](https://github.com/koppor/jabref/issues/520)
+
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/copyfiles/CopyFilesAction.java
+++ b/src/main/java/org/jabref/gui/copyfiles/CopyFilesAction.java
@@ -55,7 +55,6 @@ public class CopyFilesAction extends SimpleCommand {
 
     @Override
     public void execute() {
-        System.out.println("开始执行 execute 方法");
 
         BibDatabaseContext database = stateManager.getActiveDatabase().orElseThrow(() -> new NullPointerException("Database null"));
         List<BibEntry> entries = stateManager.getSelectedEntries();

--- a/src/main/java/org/jabref/gui/copyfiles/CopyFilesAction.java
+++ b/src/main/java/org/jabref/gui/copyfiles/CopyFilesAction.java
@@ -1,9 +1,13 @@
 package org.jabref.gui.copyfiles;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Optional;
 
+import javafx.application.Platform;
 import javafx.concurrent.Task;
 
 import org.jabref.gui.DialogService;
@@ -15,9 +19,12 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.LinkedFile;
+
 
 import static org.jabref.gui.actions.ActionHelper.needsDatabase;
 import static org.jabref.gui.actions.ActionHelper.needsEntriesSelected;
+import static org.jabref.gui.edit.automaticfiededitor.AbstractAutomaticFieldEditorTabViewModel.LOGGER;
 
 public class CopyFilesAction extends SimpleCommand {
 
@@ -48,6 +55,8 @@ public class CopyFilesAction extends SimpleCommand {
 
     @Override
     public void execute() {
+        System.out.println("开始执行 execute 方法");
+
         BibDatabaseContext database = stateManager.getActiveDatabase().orElseThrow(() -> new NullPointerException("Database null"));
         List<BibEntry> entries = stateManager.getSelectedEntries();
 
@@ -63,7 +72,29 @@ public class CopyFilesAction extends SimpleCommand {
                     Localization.lang("Copy linked files to folder..."),
                     exportTask);
 
+            LOGGER.info("Creating CopyFilesTask with path: " + path);
+            for (BibEntry entry : entries) {
+                List<LinkedFile> linkedFiles = entry.getFiles();
+                for (LinkedFile file : linkedFiles) {
+                    Optional<Path> sourcePath = file.findIn(List.of(path));
+                    if (sourcePath.isPresent()) {
+                        Path targetPath = path.resolve(sourcePath.get().getFileName());
+                        try {
+                            Files.copy(sourcePath.get(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+                            LinkedFile newLinkedFile = new LinkedFile(file.getDescription(), targetPath.toString(), file.getFileType());
+                            entry.addFile(newLinkedFile);
+                            LOGGER.info("Successfully copied file: " + sourcePath.get() + " to " + targetPath);
+                        } catch (IOException e) {
+                            LOGGER.error("Failed to copy file: " + sourcePath.get() + " to " + targetPath, e);
+                        }
+                    }else{
+                        LOGGER.warn("Source file not found or doesn't exist: {}", file.getLink());
+                    }
+                }
+            }
             uiTaskExecutor.execute(exportTask);
+
+            LOGGER.info("CopyFilesTask has been executed.");
             exportTask.setOnSucceeded(e -> showDialog(exportTask.getValue()));
         });
     }

--- a/src/main/java/org/jabref/gui/copyfiles/CopyFilesDialogView.java
+++ b/src/main/java/org/jabref/gui/copyfiles/CopyFilesDialogView.java
@@ -59,3 +59,4 @@ public class CopyFilesDialogView extends BaseDialog<Void> {
         tvResult.setColumnResizePolicy(param -> true);
     }
 }
+

--- a/src/main/java/org/jabref/gui/copyfiles/CopyFilesTask.java
+++ b/src/main/java/org/jabref/gui/copyfiles/CopyFilesTask.java
@@ -85,6 +85,7 @@ public class CopyFilesTask extends Task<List<CopyFilesResultItemViewModel>> {
 
                     if (newPath.isPresent()) {
                         Path newFile = newPath.get();
+                        LOGGER.info("Calling copyFile method...");
                         boolean success = FileUtil.copyFile(fileToExport.get(), newFile, false);
                         updateProgress(totalFilesCounter++, totalFilesCount);
                         try {
@@ -97,6 +98,7 @@ public class CopyFilesTask extends Task<List<CopyFilesResultItemViewModel>> {
                         }
                         if (success) {
                             updateMessage(localizedSuccessMessage);
+                            fileName.setLink(newFile.toString());
                             numberSuccessful++;
                             writeLogMessage(newFile, bw, localizedSuccessMessage);
                             addResultToList(newFile, success, localizedSuccessMessage);

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -228,7 +228,9 @@ public class FileUtil {
         }
         try {
             // This should also preserve Hard Links
+            LOGGER.info("Attempting to copy file from " + pathToSourceFile + " to " + pathToDestinationFile);
             Files.copy(pathToSourceFile, pathToDestinationFile, StandardCopyOption.REPLACE_EXISTING);
+            LOGGER.info("File copied successfully.");
             return true;
         } catch (IOException e) {
             LOGGER.error("Copying Files failed.", e);


### PR DESCRIPTION
Describe the changes you have made here: what, why, ...
This pull request fixes the issue where associated PDF files were not being copied when entries were moved from one .bib file to another. Now, when copying entries, the linked PDFs are also transferred to the correct folder for the target .bib file.

Changes Made:
Updated copyEntry() to store the source .bib file context.
Modified pasteEntry() to copy linked PDFs to the target .bib file's directory.

Link the issue that will be closed: (https://github.com/koppor/jabref/issues/520)
### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
